### PR TITLE
Increase lint level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,18 +60,18 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 dependencies = [
  "backtrace",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -249,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "byteorder"
@@ -288,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "cbindgen"
-version = "0.23.0"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6d248e3ca02f3fbfabcb9284464c596baec223a26d91bbf44a5a62ddb0d900"
+checksum = "a6358dedf60f4d9b8db43ad187391afe959746101346fe51bb978126bec61dfb"
 dependencies = [
  "clap",
  "heck 0.4.0",
@@ -330,7 +330,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.43",
+ "time 0.1.44",
  "winapi",
 ]
 
@@ -368,16 +368,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.18"
+version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -398,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -498,15 +498,15 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
+ "once_cell",
  "scopeguard",
 ]
 
@@ -522,12 +522,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 dependencies = [
  "cfg-if",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -542,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "5999502d32b9c48d492abe66392408144895020ec4709e549e840799f3bb74c0"
 dependencies = [
  "generic-array",
  "typenum",
@@ -606,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "diff"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -673,18 +673,25 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "email-encoding"
-version = "0.1.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690291166824e467790ac08ba42f241791567e8337bbf00c5a6e87889629f98"
+checksum = "34dd14c63662e0206599796cd5e1ad0268ab2b9d19b868d6050d688eba2bbf98"
 dependencies = [
  "base64 0.13.0",
+ "memchr",
 ]
+
+[[package]]
+name = "email_address"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8684b7c9cb4857dfa1e5b9629ef584ba618c9b93bae60f58cb23f4f271d0468e"
 
 [[package]]
 name = "encode_unicode"
@@ -757,14 +764,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0408e2626025178a6a7f7ffc05a25bc47103229f19c113755de7bf63816290c"
+checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -779,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.10.12"
+version = "0.10.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843c03199d0c0ca54bc1ea90ac0d507274c28abcc4f691ae8b4eaa375087c76a"
+checksum = "1ceeb589a3157cac0ab8cc585feb749bd2cea5cb55a6ee802ad72d9fd38303da"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -973,14 +980,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -998,9 +1005,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "globset"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
+checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1024,7 +1031,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.2",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1119,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
@@ -1225,12 +1232,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown 0.12.1",
  "serde",
 ]
 
@@ -1262,9 +1269,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689960f187c43c01650c805fb6bc6f55ab944499d86d4ffe9474ad78991d8e94"
+checksum = "4126dd76ebfe2561486a1bd6738a33d2029ffb068a99ac446b7f8c77b2e58dbc"
 dependencies = [
  "console",
  "once_cell",
@@ -1321,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1365,13 +1372,14 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "lettre"
-version = "0.10.0-rc.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f6c70001f7ee6c93b6687a06607c7a38f9a7ae460139a496c23da21e95bc289"
+checksum = "5677c78c7c7ede1dd68e8a7078012bc625449fb304e7b509b917eaaedfe6e849"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
  "email-encoding",
+ "email_address",
  "fastrand",
  "futures-io",
  "futures-util",
@@ -1382,9 +1390,9 @@ dependencies = [
  "nom",
  "once_cell",
  "quoted_printable",
- "regex",
  "rustls 0.20.6",
- "rustls-pemfile 1.0.0",
+ "rustls-pemfile",
+ "socket2",
  "tokio",
  "tokio-rustls 0.23.4",
  "webpki-roots 0.22.3",
@@ -1428,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -1555,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
@@ -1672,7 +1680,7 @@ dependencies = [
  "sha2",
  "sqlx",
  "sunfish",
- "time 0.3.9",
+ "time 0.3.11",
  "tokio",
  "toml",
  "tracing",
@@ -1734,7 +1742,7 @@ dependencies = [
  "serde_urlencoded",
  "sqlx",
  "sunfish",
- "time 0.3.9",
+ "time 0.3.11",
  "tracing",
 ]
 
@@ -1787,7 +1795,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "sunfish",
- "time 0.3.9",
+ "time 0.3.11",
  "tokio",
  "tracing",
  "tracing-test",
@@ -2053,7 +2061,7 @@ dependencies = [
  "serde_urlencoded",
  "sqlx",
  "sunfish",
- "time 0.3.9",
+ "time 0.3.11",
 ]
 
 [[package]]
@@ -2174,7 +2182,7 @@ dependencies = [
  "serde_urlencoded",
  "sqlx",
  "sunfish",
- "time 0.3.9",
+ "time 0.3.11",
 ]
 
 [[package]]
@@ -3927,9 +3935,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fbc387afefefd5e9e39493299f3069e14a140dd34dc19b4c1c1a8fddb6a790"
+checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
 dependencies = [
  "num-traits",
 ]
@@ -3957,9 +3965,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
  "num-bigint",
@@ -4065,9 +4073,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
  "parking_lot_core 0.9.3",
@@ -4203,18 +4211,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4348,9 +4356,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
@@ -4376,7 +4384,7 @@ dependencies = [
  "cfg-if",
  "indoc",
  "libc",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -4428,9 +4436,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -4573,9 +4581,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
+checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
  "base64 0.13.0",
  "bytes",
@@ -4595,13 +4603,14 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.20.6",
- "rustls-pemfile 0.3.0",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-rustls 0.23.4",
- "tokio-util 0.6.10",
+ "tokio-util",
+ "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4679,7 +4688,7 @@ dependencies = [
  "serde_derive",
  "sha2",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.11",
  "tokio",
  "tokio-stream",
  "url",
@@ -4714,15 +4723,6 @@ dependencies = [
  "ring",
  "sct 0.7.0",
  "webpki 0.22.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
-dependencies = [
- "base64 0.13.0",
 ]
 
 [[package]]
@@ -4783,9 +4783,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
 dependencies = [
  "serde_derive",
 ]
@@ -4824,9 +4824,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4835,9 +4835,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "itoa 1.0.2",
  "ryu",
@@ -4949,9 +4949,9 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "smawk"
@@ -5167,9 +5167,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.95"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5274,19 +5274,20 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
 dependencies = [
  "itoa 1.0.2",
  "libc",
@@ -5317,9 +5318,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.18.2"
+version = "1.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
+checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
 dependencies = [
  "bytes",
  "libc",
@@ -5327,7 +5328,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -5337,9 +5338,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5370,9 +5371,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5381,23 +5382,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.10"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
+checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5435,15 +5422,15 @@ dependencies = [
 
 [[package]]
 name = "tower-service"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -5453,9 +5440,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5464,11 +5451,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
- "lazy_static",
+ "once_cell",
  "valuable",
 ]
 
@@ -5495,13 +5482,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
+checksum = "3a713421342a5a666b7577783721d3117f1b69a393df803ee17bb73b1e122a59"
 dependencies = [
  "ansi_term",
- "lazy_static",
  "matchers",
+ "once_cell",
  "regex",
  "serde",
  "serde_json",
@@ -5516,9 +5503,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-test"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb7bda2e93bbc9c5b247034acc6a4b3d04f033a3d4b8fc1cb87d4d1c7c7ebd7"
+checksum = "f6992d8a98f570be1c729fe8b6f464fb18c4117054c10f1f952c22d533b48a74"
 dependencies = [
  "lazy_static",
  "tracing-core",
@@ -5528,9 +5515,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-test-macro"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4801dca35e4e2cee957c469bd4a1c370fadb7894c0d50721a40eba3523e6e91c"
+checksum = "719fa6c65bada6a7a3b8466702ec6fb4c4189b69339f78c9e597f796e493712e"
 dependencies = [
  "lazy_static",
  "quote",
@@ -5550,9 +5537,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.6"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3b781640108d29892e8b9684642d2cda5ea05951fd58f0fea1db9edeb9b71"
+checksum = "268bf3e3ca0c09e5d21b59c2638e12cb6dcf7ea2681250a696a2d0936cb57ba0"
 dependencies = [
  "cc",
  "regex",
@@ -5627,9 +5614,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-linebreak"
@@ -5642,9 +5629,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
 dependencies = [
  "tinyvec",
 ]
@@ -5765,9 +5752,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -5777,9 +5764,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
 dependencies = [
  "cfg-if",
  "serde",
@@ -5789,9 +5776,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -5804,9 +5791,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-cli-support"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab11a7bfc3e3d5c075ee93626160b720a1cd9c320a9b932be4fc243dea9ed507"
+checksum = "4016fbd42224de21aab2f009aeaec61067d278a298ba7f8f7f8d40fbffea0822"
 dependencies = [
  "anyhow",
  "base64 0.9.3",
@@ -5828,9 +5815,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-externref-xform"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f23b0f14e12b08bcf95b75d1896771afbdd0a4167c889d202b81ed7858e3d5"
+checksum = "f33c8e2d3f3b6f6647f982911eb4cb44998c8cca97a4fe7afc99f616ebb33a73"
 dependencies = [
  "anyhow",
  "walrus",
@@ -5838,9 +5825,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
+checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5850,9 +5837,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5860,9 +5847,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5873,9 +5860,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-multi-value-xform"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eae02fd62b4954e74bd808ff160b58932b9a208e03a69e5776460655df11ed5"
+checksum = "7015b54357604811162710d5cf274ab85d974fe1e324222dd5b2133afdefe9b9"
 dependencies = [
  "anyhow",
  "walrus",
@@ -5883,15 +5870,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
 
 [[package]]
 name = "wasm-bindgen-threads-xform"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d5d14d234eb095de93a856f4740f0f46e57e58f7cb5c303b35ff3e9db189e90"
+checksum = "6961b838d9a9c121ba4a1eea1628014cc759469e3defb42bbac9c5ed0f65be14"
 dependencies = [
  "anyhow",
  "walrus",
@@ -5900,9 +5887,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-wasm-conventions"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0febe9c6944f60dd5d38359ef5ab3eab82e8ac7a6e9b3961e4357d89192db686"
+checksum = "c0a0eca38fe89471f57d6903f3e17e732d2d6f995a7af5b23f27df7fee0f0d18"
 dependencies = [
  "anyhow",
  "walrus",
@@ -5910,9 +5897,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-wasm-interpreter"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e3e00a34cb517890ac55321277286ac5e072f7076ab62eb85d58a781449d24"
+checksum = "0b1c9fb7f71137840932bbb853ef1f83d68c88584b716c9bbae38675c9fb8b86"
 dependencies = [
  "anyhow",
  "log",
@@ -5943,9 +5930,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6002,7 +5989,7 @@ dependencies = [
  "serde",
  "sha2",
  "textwrap",
- "time 0.3.9",
+ "time 0.3.11",
  "toml",
  "walkdir",
  "zip",
@@ -6031,9 +6018,9 @@ dependencies = [
 
 [[package]]
 name = "wildmatch"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c48bd20df7e4ced539c12f570f937c6b4884928a87fee70a479d72f031d4e0"
+checksum = "ee583bdc5ff1cf9db20e9db5bb3ff4c3089a8f6b8b31aff265c9aba85812db86"
 
 [[package]]
 name = "winapi"
@@ -6217,9 +6204,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"
+checksum = "20b578acffd8516a6c3f2a1bdefc1ec37e547bb4e0fb8b6b01a4cafc886b4442"
 
 [[package]]
 name = "zip"
@@ -6237,7 +6224,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1",
- "time 0.3.9",
+ "time 0.3.11",
  "zstd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,7 +2975,6 @@ dependencies = [
 name = "modelfox_build"
 version = "0.8.0"
 dependencies = [
- "anyhow",
  "cbindgen",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ base64 = "0.13"
 bitvec = "1.0"
 buffalo = { version = "0.4", features = ["bitvec", "ndarray"] }
 bytes = "1.1"
-cbindgen = "0.23"
+cbindgen = "0.24"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = { version = "0.6", features = ["serde"] }
 clap = { version = "3.1", features = ["derive"] }

--- a/crates/app/core/alert_sender.rs
+++ b/crates/app/core/alert_sender.rs
@@ -187,7 +187,7 @@ async fn handle_alert_send_with_decay(
 	Ok(())
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AlertSendStatus {
 	Unsent,
 	Sending,

--- a/crates/app/layouts/model_layout.rs
+++ b/crates/app/layouts/model_layout.rs
@@ -170,7 +170,7 @@ async fn delete_model(
 	Ok(response)
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum ModelNavItem {
 	Overview,
 	TrainingGrid,

--- a/crates/app/routes/login/server/page.rs
+++ b/crates/app/routes/login/server/page.rs
@@ -8,7 +8,7 @@ pub struct Page {
 	pub error: Option<String>,
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum Stage {
 	Email,
 	Code,

--- a/crates/app/routes/repos/_/models/_/production_predictions/index/server/get.rs
+++ b/crates/app/routes/repos/_/models/_/production_predictions/index/server/get.rs
@@ -60,7 +60,7 @@ pub async fn get(request: &mut http::Request<hyper::Body>) -> Result<http::Respo
 	let before = search_params.as_ref().and_then(|s| s.before);
 	let rows = match (after, before) {
 		(Some(after), None) => {
-			let rows = sqlx::query(
+			sqlx::query(
 				"
 					select
 						id,
@@ -89,8 +89,7 @@ pub async fn get(request: &mut http::Request<hyper::Body>) -> Result<http::Respo
 			.bind(after)
 			.bind(PRODUCTION_PREDICTIONS_NUM_PREDICTIONS_PER_PAGE_TABLE)
 			.fetch_all(db.borrow_mut())
-			.await?;
-			rows
+			.await?
 		}
 		(None, Some(before)) => {
 			sqlx::query(

--- a/crates/app/routes/repos/new/server/post.rs
+++ b/crates/app/routes/repos/new/server/post.rs
@@ -37,7 +37,7 @@ pub async fn post(request: &mut http::Request<hyper::Body>) -> Result<http::Resp
 	let repo_id = if let Some(owner) = &owner {
 		let repo_id = Id::generate();
 		let owner_parts: Vec<&str> = owner.split(':').collect();
-		let owner_type = match owner_parts.get(0) {
+		let owner_type = match owner_parts.first() {
 			Some(owner_type) => owner_type,
 			None => return Ok(bad_request()),
 		};

--- a/crates/app/ui/column_type.rs
+++ b/crates/app/ui/column_type.rs
@@ -1,4 +1,4 @@
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub enum ColumnType {
 	Unknown,
 	Number,

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -17,7 +17,6 @@ name = "modelfox_build"
 path = "main.rs"
 
 [dependencies]
-anyhow = { workspace = true }
 cbindgen = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }

--- a/crates/build/main.rs
+++ b/crates/build/main.rs
@@ -830,7 +830,7 @@ pub enum Arch {
 	X8664,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Target {
 	AArch64LinuxGnu,
 	AArch64LinuxMusl,

--- a/crates/charts/bar_chart.rs
+++ b/crates/charts/bar_chart.rs
@@ -22,15 +22,15 @@ impl ChartImpl for BarChart {
 	type HoverRegionInfo = BarChartHoverRegionInfo;
 
 	fn draw_chart(
-		options: DrawChartOptions<Self::Options>,
+		options: &DrawChartOptions<Self::Options>,
 	) -> DrawChartOutput<Self::OverlayInfo, Self::HoverRegionInfo> {
 		draw_bar_chart(options)
 	}
 
 	fn draw_overlay(
-		options: DrawOverlayOptions<Self::Options, Self::OverlayInfo, Self::HoverRegionInfo>,
+		options: &DrawOverlayOptions<Self::Options, Self::OverlayInfo, Self::HoverRegionInfo>,
 	) {
-		draw_bar_chart_overlay(options)
+		draw_bar_chart_overlay(options);
 	}
 }
 
@@ -78,8 +78,9 @@ pub struct BarChartHoverRegionInfo {
 	pub tooltip_origin_pixels: Point,
 }
 
+#[allow(clippy::too_many_lines)]
 fn draw_bar_chart(
-	options: DrawChartOptions<BarChartOptions>,
+	options: &DrawChartOptions<BarChartOptions>,
 ) -> DrawChartOutput<BarChartOverlayInfo, BarChartHoverRegionInfo> {
 	let DrawChartOptions {
 		chart_colors,
@@ -172,7 +173,7 @@ fn draw_bar_chart(
 			ctx,
 			group_width: bar_group_width,
 			width,
-		})
+		});
 	}
 
 	draw_y_axis_grid_lines(DrawYAxisGridLinesOptions {
@@ -183,7 +184,7 @@ fn draw_bar_chart(
 		y_axis_grid_line_info: &y_axis_grid_line_info,
 	});
 
-	draw_x_axis(DrawXAxisOptions {
+	draw_x_axis(&DrawXAxisOptions {
 		chart_colors,
 		chart_config,
 		ctx,
@@ -201,12 +202,12 @@ fn draw_bar_chart(
 			grid_line_info: &y_axis_grid_line_info,
 			height,
 			number_formatter: &options.number_formatter,
-		})
+		});
 	}
 
 	// Draw the X axis title.
 	if let Some(x_axis_title) = x_axis_title {
-		draw_x_axis_title(DrawXAxisTitleOptions {
+		draw_x_axis_title(&DrawXAxisTitleOptions {
 			chart_colors,
 			rect: x_axis_title_rect,
 			ctx,
@@ -216,7 +217,7 @@ fn draw_bar_chart(
 
 	// Draw the Y axis title.
 	if let Some(y_axis_title) = y_axis_title {
-		draw_y_axis_title(DrawYAxisTitleOptions {
+		draw_y_axis_title(&DrawYAxisTitleOptions {
 			chart_colors,
 			rect: y_axis_title_rect,
 			ctx,
@@ -289,6 +290,7 @@ fn draw_bar_chart(
 	}
 }
 
+#[derive(Clone, Copy)]
 struct DrawBarOptions<'a> {
 	chart_config: &'a ChartConfig,
 	color: &'a str,
@@ -323,9 +325,10 @@ fn draw_bar(options: DrawBarOptions) {
 		radius,
 		stroke_color: Some(color),
 		stroke_width: Some(chart_config.bar_stroke_width),
-	})
+	});
 }
 
+#[derive(Clone, Copy)]
 pub struct DrawBarChartXAxisLabelsOptions<'a> {
 	pub bar_group_gap: f64,
 	pub chart_colors: &'a ChartColors,
@@ -336,6 +339,9 @@ pub struct DrawBarChartXAxisLabelsOptions<'a> {
 	pub width: f64,
 }
 
+/// # Panics
+///
+/// This function will fail is the draw call to the `CanvasRenderingContext2d` handle fails.
 pub fn draw_bar_chart_x_axis_labels(options: DrawBarChartXAxisLabelsOptions) {
 	let DrawBarChartXAxisLabelsOptions {
 		bar_group_gap,
@@ -369,9 +375,8 @@ pub fn draw_bar_chart_x_axis_labels(options: DrawBarChartXAxisLabelsOptions) {
 		if overlap {
 			label_step_size += 1;
 			continue;
-		} else {
-			break;
 		}
+		break;
 	}
 	// Render every `label_step_size` label.
 	for (label_index, label) in categories.iter().enumerate().step_by(label_step_size) {
@@ -393,7 +398,7 @@ pub fn draw_bar_chart_x_axis_labels(options: DrawBarChartXAxisLabelsOptions) {
 }
 
 fn draw_bar_chart_overlay(
-	options: DrawOverlayOptions<BarChartOptions, BarChartOverlayInfo, BarChartHoverRegionInfo>,
+	options: &DrawOverlayOptions<BarChartOptions, BarChartOverlayInfo, BarChartHoverRegionInfo>,
 ) {
 	if let Some(active_hover_region) = options.active_hover_regions.get(0) {
 		let series_title = &active_hover_region.info.series_title;
@@ -425,6 +430,6 @@ fn draw_bar_chart_overlay(
 			color: "#00000022",
 			ctx: options.ctx,
 			rect: active_hover_region.info.rect,
-		})
+		});
 	}
 }

--- a/crates/charts/common.rs
+++ b/crates/charts/common.rs
@@ -18,6 +18,8 @@ use web_sys as dom;
 // |   	|                X Axis Title                 |
 // |--------------------------------------------------|
 
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Clone, Copy)]
 pub struct ComputeRectsOptions<'a> {
 	pub chart_config: &'a ChartConfig,
 	pub ctx: &'a dom::CanvasRenderingContext2d,
@@ -75,6 +77,8 @@ pub struct GridLineInfo {
 	pub start_pixels: f64,
 }
 
+#[allow(clippy::too_many_lines)]
+#[must_use]
 pub fn compute_rects(options: ComputeRectsOptions) -> ComputeRectsOutput {
 	let ComputeRectsOptions {
 		chart_config:
@@ -264,6 +268,10 @@ fn compute_grid_line_interval(
 	}
 }
 
+/// # Panics
+///
+/// This function panics if the `num_grid_lines` calculation fails to cast to `usize`.
+#[must_use]
 pub fn compute_grid_line_info(
 	min: f64,
 	max: f64,
@@ -298,6 +306,12 @@ pub struct ComputeXAxisGridLineInfoOptions<'a> {
 	pub x_min: f64,
 }
 
+/// # Panics
+///
+/// This function has two possible panics:
+/// 1. The `grid_line_index` fails to cast from `usize` to `f64.`
+/// 1. The `ctx` is unable to preform the `measure_text()` FFI method.
+#[must_use]
 pub fn compute_x_axis_grid_line_info(options: ComputeXAxisGridLineInfoOptions) -> GridLineInfo {
 	let ComputeXAxisGridLineInfoOptions {
 		chart_width,
@@ -334,6 +348,7 @@ pub fn compute_x_axis_grid_line_info(options: ComputeXAxisGridLineInfoOptions) -
 	}
 }
 
+#[derive(Clone, Copy)]
 pub struct ComputeYAxisGridLineInfoOptions<'a> {
 	chart_height: f64,
 	font_size: f64,
@@ -342,6 +357,7 @@ pub struct ComputeYAxisGridLineInfoOptions<'a> {
 	y_min: f64,
 }
 
+#[must_use]
 pub fn compute_y_axis_grid_line_info(options: ComputeYAxisGridLineInfoOptions) -> GridLineInfo {
 	let ComputeYAxisGridLineInfoOptions {
 		y_axis_grid_line_interval,
@@ -380,6 +396,9 @@ pub struct DrawXAxisGridLinesOptions<'a> {
 	pub x_axis_grid_line_info: GridLineInfo,
 }
 
+/// # Panics
+///
+///  This function panics if unable to cast the `grid_line_index` from `usize` to `f64`.
 pub fn draw_x_axis_grid_lines(options: DrawXAxisGridLinesOptions) {
 	let DrawXAxisGridLinesOptions {
 		chart_colors,
@@ -410,7 +429,10 @@ pub struct DrawXAxisOptions<'a> {
 	pub y_axis_grid_line_info: &'a GridLineInfo,
 }
 
-pub fn draw_x_axis(options: DrawXAxisOptions) {
+/// # Panics
+///
+///  This function panics if unable to cast the `grid_line_index` from `usize` to `f64`.
+pub fn draw_x_axis(options: &DrawXAxisOptions) {
 	let DrawXAxisOptions {
 		chart_colors,
 		chart_config,
@@ -436,6 +458,7 @@ pub fn draw_x_axis(options: DrawXAxisOptions) {
 	}
 }
 
+#[derive(Clone, Copy)]
 pub struct DrawYAxisGridLinesOptions<'a> {
 	pub chart_colors: &'a ChartColors,
 	pub chart_config: &'a ChartConfig,
@@ -444,6 +467,9 @@ pub struct DrawYAxisGridLinesOptions<'a> {
 	pub y_axis_grid_line_info: &'a GridLineInfo,
 }
 
+/// # Panics
+///
+///  This function panics if unable to cast the `grid_line_index` from `usize` to `f64`.
 pub fn draw_y_axis_grid_lines(options: DrawYAxisGridLinesOptions) {
 	let DrawYAxisGridLinesOptions {
 		chart_colors,
@@ -462,7 +488,7 @@ pub fn draw_y_axis_grid_lines(options: DrawYAxisGridLinesOptions) {
 		ctx.set_line_cap("square");
 		ctx.move_to(rect.x, y);
 		ctx.line_to(rect.x + rect.w, y);
-		ctx.stroke()
+		ctx.stroke();
 	}
 }
 
@@ -474,7 +500,10 @@ pub struct DrawYAxisOptions<'a> {
 	pub x_axis_grid_line_info: &'a GridLineInfo,
 }
 
-pub fn draw_y_axis(options: DrawYAxisOptions) {
+/// # Panics
+///
+///  This function panics if unable to cast the `grid_line_index` from `usize` to `f64`.
+pub fn draw_y_axis(options: &DrawYAxisOptions) {
 	let DrawYAxisOptions {
 		chart_colors,
 		chart_config,
@@ -510,6 +539,10 @@ pub struct DrawXAxisLabelsOptions<'a> {
 	pub width: f64,
 }
 
+/// # Panics
+///
+/// This function panics if unable to cast the `grid_line_index` from `usize` to `f64`.
+/// It also panics if any FFI method calls to the `ctx` fail.
 pub fn draw_x_axis_labels(options: DrawXAxisLabelsOptions) {
 	let DrawXAxisLabelsOptions {
 		chart_colors,
@@ -557,6 +590,7 @@ pub fn draw_x_axis_labels(options: DrawXAxisLabelsOptions) {
 	}
 }
 
+#[derive(Clone, Copy)]
 pub struct DrawYAxisLabelsOptions<'a> {
 	pub chart_colors: &'a ChartColors,
 	pub rect: Rect,
@@ -567,6 +601,9 @@ pub struct DrawYAxisLabelsOptions<'a> {
 	pub number_formatter: &'a NumberFormatter,
 }
 
+/// # Panics
+///
+///  This function panics if unable to cast the `grid_line_index` from `usize` to `f64`.
 pub fn draw_y_axis_labels(options: DrawYAxisLabelsOptions) {
 	let DrawYAxisLabelsOptions {
 		chart_colors,
@@ -607,7 +644,10 @@ pub struct DrawXAxisTitleOptions<'a> {
 	pub title: &'a str,
 }
 
-pub fn draw_x_axis_title(options: DrawXAxisTitleOptions) {
+/// # Panics
+///
+/// This function panics if the FFI `ctx,fill_text()` method call fails.
+pub fn draw_x_axis_title(options: &DrawXAxisTitleOptions) {
 	let DrawXAxisTitleOptions {
 		chart_colors,
 		ctx,
@@ -631,7 +671,10 @@ pub struct DrawYAxisTitleOptions<'a> {
 	pub title: &'a str,
 }
 
-pub fn draw_y_axis_title(options: DrawYAxisTitleOptions) {
+/// # Panics
+///
+/// This function panics if the FFI method calls to the `ctx` fail.
+pub fn draw_y_axis_title(options: &DrawYAxisTitleOptions) {
 	let DrawYAxisTitleOptions {
 		chart_colors,
 		ctx,
@@ -650,6 +693,8 @@ pub fn draw_y_axis_title(options: DrawYAxisTitleOptions) {
 	ctx.restore();
 }
 
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Clone, Copy)]
 pub struct DrawRoundedRectOptions<'a> {
 	pub ctx: &'a dom::CanvasRenderingContext2d,
 	pub fill_color: Option<&'a str>,
@@ -663,6 +708,9 @@ pub struct DrawRoundedRectOptions<'a> {
 	pub stroke_width: Option<f64>,
 }
 
+/// # Panics
+///
+/// This function panics if the FFI `ctx` method calls fail.
 pub fn draw_rounded_rect(options: DrawRoundedRectOptions) {
 	let DrawRoundedRectOptions {
 		ctx,

--- a/crates/charts/components.rs
+++ b/crates/charts/components.rs
@@ -78,12 +78,12 @@ impl Component for BarChart {
 			})
 			.collect();
 		let title = self.title.map(ChartTitle::new);
-		let legend = if !hide_legend {
+		let legend = if hide_legend {
+			None
+		} else {
 			Some(ChartLegend {
 				items: legend_items,
 			})
-		} else {
-			None
 		};
 		let chart = div()
 			.style(style::PADDING_TOP, "50%")
@@ -168,12 +168,12 @@ impl Component for BoxChart {
 			})
 			.collect();
 		let title = self.title.map(ChartTitle::new);
-		let legend = if !hide_legend {
+		let legend = if hide_legend {
+			None
+		} else {
 			Some(ChartLegend {
 				items: legend_items,
 			})
-		} else {
-			None
 		};
 		let chart = div()
 			.style(style::PADDING_TOP, "50%")
@@ -362,12 +362,12 @@ impl Component for LineChart {
 			})
 			.collect();
 		let title = self.title.map(ChartTitle::new);
-		let legend = if !hide_legend {
+		let legend = if hide_legend {
+			None
+		} else {
 			Some(ChartLegend {
 				items: legend_items,
 			})
-		} else {
-			None
 		};
 		let chart = div()
 			.style(style::PADDING_TOP, "50%")

--- a/crates/charts/feature_contributions_chart.rs
+++ b/crates/charts/feature_contributions_chart.rs
@@ -24,15 +24,15 @@ impl ChartImpl for FeatureContributionsChart {
 	type HoverRegionInfo = FeatureContributionsChartHoverRegionInfo;
 
 	fn draw_chart(
-		options: DrawChartOptions<Self::Options>,
+		options: &DrawChartOptions<Self::Options>,
 	) -> DrawChartOutput<Self::OverlayInfo, Self::HoverRegionInfo> {
 		draw_feature_contributions_chart(options)
 	}
 
 	fn draw_overlay(
-		options: DrawOverlayOptions<Self::Options, Self::OverlayInfo, Self::HoverRegionInfo>,
+		options: &DrawOverlayOptions<Self::Options, Self::OverlayInfo, Self::HoverRegionInfo>,
 	) {
-		draw_feature_contributions_chart_overlay(options)
+		draw_feature_contributions_chart_overlay(options);
 	}
 }
 
@@ -92,8 +92,10 @@ pub struct FeatureContributionsChartHoverRegionInfo {
 
 pub struct FeatureContributionsChartOverlayInfo {}
 
+#[allow(clippy::too_many_lines)]
+#[allow(clippy::similar_names)]
 fn draw_feature_contributions_chart(
-	options: DrawChartOptions<FeatureContributionsChartOptions>,
+	options: &DrawChartOptions<FeatureContributionsChartOptions>,
 ) -> DrawChartOutput<FeatureContributionsChartOverlayInfo, FeatureContributionsChartHoverRegionInfo>
 {
 	let DrawChartOptions {
@@ -217,12 +219,12 @@ fn draw_feature_contributions_chart(
 		y: *top_padding,
 	};
 	if include_x_axis_title {
-		draw_x_axis_title(DrawXAxisTitleOptions {
+		draw_x_axis_title(&DrawXAxisTitleOptions {
 			chart_colors,
 			rect: top_x_axis_title_rect,
 			ctx,
 			title: "Contributions",
-		})
+		});
 	}
 
 	let top_x_axis_labels_rect = Rect {
@@ -309,7 +311,7 @@ fn draw_feature_contributions_chart(
 	};
 
 	if include_y_axis_title {
-		draw_y_axis_title(DrawYAxisTitleOptions {
+		draw_y_axis_title(&DrawYAxisTitleOptions {
 			chart_colors,
 			rect: y_axis_titles_rect,
 			ctx,
@@ -362,7 +364,7 @@ fn draw_feature_contributions_chart(
 		.collect::<Vec<_>>();
 	if include_y_axis_labels {
 		draw_feature_contributions_chart_y_axis_labels(
-			DrawFeatureContributionsChartYAxisLabelsOptions {
+			&DrawFeatureContributionsChartYAxisLabelsOptions {
 				rect: y_axis_labels_rect,
 				categories: &categories,
 				ctx,
@@ -394,7 +396,7 @@ fn draw_feature_contributions_chart(
 			.map(|value| value.value)
 			.sum::<f64>();
 		if let Some(sum_compressed_positives) = &series.compressed_positive_values {
-			sum_positives += sum_compressed_positives.sum
+			sum_positives += sum_compressed_positives.sum;
 		};
 		let min = series.baseline.min(series.output);
 		let max = series.baseline + sum_positives;
@@ -430,6 +432,7 @@ fn draw_feature_contributions_chart(
 	}
 }
 
+#[derive(Clone, Copy)]
 struct DrawFeatureContributionSeriesOptions<'a> {
 	chart_config: &'a ChartConfig,
 	rect: Rect,
@@ -445,6 +448,7 @@ struct DrawFeatureContributionsSeriesOutput {
 	hover_regions: Vec<HoverRegion<FeatureContributionsChartHoverRegionInfo>>,
 }
 
+#[allow(clippy::too_many_lines)]
 fn draw_feature_contribution_series(
 	options: DrawFeatureContributionSeriesOptions,
 ) -> DrawFeatureContributionsSeriesOutput {
@@ -590,7 +594,7 @@ fn draw_feature_contribution_series(
 					y: remaining_features_rect.y,
 				},
 			},
-		))
+		));
 	}
 	for negative_value in negative_values {
 		let feature_contribution_value = negative_value;
@@ -650,7 +654,7 @@ struct DrawFeatureContributionsChartYAxisLabelsOptions<'a> {
 }
 
 fn draw_feature_contributions_chart_y_axis_labels(
-	options: DrawFeatureContributionsChartYAxisLabelsOptions,
+	options: &DrawFeatureContributionsChartYAxisLabelsOptions,
 ) {
 	let DrawFeatureContributionsChartYAxisLabelsOptions {
 		chart_config,
@@ -671,7 +675,7 @@ fn draw_feature_contributions_chart_y_axis_labels(
 }
 
 fn draw_feature_contributions_chart_overlay(
-	options: DrawOverlayOptions<
+	options: &DrawOverlayOptions<
 		FeatureContributionsChartOptions,
 		FeatureContributionsChartOverlayInfo,
 		FeatureContributionsChartHoverRegionInfo,
@@ -685,13 +689,13 @@ fn draw_feature_contributions_chart_overlay(
 		chart_colors,
 		..
 	} = options;
-	draw_feature_contribution_tooltips(DrawFeatureContributionTooltipsOptions {
+	draw_feature_contribution_tooltips(&DrawFeatureContributionTooltipsOptions {
 		chart_colors,
 		chart_config,
 		active_hover_regions,
 		overlay_div,
 	});
-	for active_hover_region in active_hover_regions {
+	for active_hover_region in *active_hover_regions {
 		draw_feature_contribution_box(DrawFeatureContributionBoxOptions {
 			rect: active_hover_region.info.rect,
 			color: "#00000022".to_owned(),
@@ -710,14 +714,14 @@ struct DrawFeatureContributionTooltipsOptions<'a> {
 	overlay_div: &'a dom::HtmlElement,
 }
 
-fn draw_feature_contribution_tooltips(options: DrawFeatureContributionTooltipsOptions) {
+fn draw_feature_contribution_tooltips(options: &DrawFeatureContributionTooltipsOptions) {
 	let DrawFeatureContributionTooltipsOptions {
 		chart_colors,
 		chart_config,
 		active_hover_regions,
 		overlay_div,
 	} = options;
-	for active_hover_region in active_hover_regions {
+	for active_hover_region in *active_hover_regions {
 		let label = TooltipLabel {
 			color: active_hover_region.info.color.clone(),
 			text: active_hover_region.info.label.clone(),
@@ -851,7 +855,7 @@ fn draw_feature_contribution_box(options: DrawFeatureContributionBoxOptions) {
 	ctx.restore();
 }
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub struct CompressFeatureContributionsChartSeriesOptions {
 	/// Determine the width of each box if the chart were drawn at this width.
 	pub chart_width: f64,
@@ -868,30 +872,34 @@ pub fn compress_feature_contributions_chart_series(
 	let min_box_width = options.min_box_width;
 	let value_width_multiplier = chart_width / (x_max - x_min);
 	let max_feature_contribution_value_to_compress = min_box_width / value_width_multiplier;
-	series.iter_mut().for_each(|feature_contribution_series| {
+	for feature_contribution_series in series.iter_mut() {
 		let mut compressed_negative_values = FeatureContributionsChartCompressedValues {
 			sum: feature_contribution_series
 				.compressed_negative_values
 				.as_ref()
-				.map(|compressed_negative_values| compressed_negative_values.sum)
-				.unwrap_or(0.0),
+				.map_or(0.0, |compressed_negative_values| {
+					compressed_negative_values.sum
+				}),
 			count: feature_contribution_series
 				.compressed_negative_values
 				.as_ref()
-				.map(|compressed_negative_values| compressed_negative_values.count)
-				.unwrap_or(0),
+				.map_or(0, |compressed_negative_values| {
+					compressed_negative_values.count
+				}),
 		};
 		let mut compressed_positive_values = FeatureContributionsChartCompressedValues {
 			sum: feature_contribution_series
 				.compressed_positive_values
 				.as_ref()
-				.map(|compressed_positive_values| compressed_positive_values.sum)
-				.unwrap_or(0.0),
+				.map_or(0.0, |compressed_positive_values| {
+					compressed_positive_values.sum
+				}),
 			count: feature_contribution_series
 				.compressed_positive_values
 				.as_ref()
-				.map(|compressed_positive_values| compressed_positive_values.count)
-				.unwrap_or(0),
+				.map_or(0, |compressed_positive_values| {
+					compressed_positive_values.count
+				}),
 		};
 		feature_contribution_series.values.retain(|value| {
 			if value.value.abs() > max_feature_contribution_value_to_compress {
@@ -909,7 +917,7 @@ pub fn compress_feature_contributions_chart_series(
 		});
 		feature_contribution_series.compressed_negative_values = Some(compressed_negative_values);
 		feature_contribution_series.compressed_positive_values = Some(compressed_positive_values);
-	});
+	}
 }
 
 fn compute_x_min_x_max(series: &[FeatureContributionsChartSeries]) -> (f64, f64) {
@@ -941,8 +949,7 @@ fn compute_x_min_x_max(series: &[FeatureContributionsChartSeries]) -> (f64, f64)
 			let sum_of_too_small_positive_values = series
 				.compressed_positive_values
 				.as_ref()
-				.map(|t| t.sum)
-				.unwrap_or(0.0);
+				.map_or(0.0, |t| t.sum);
 			series.baseline + sum_of_positive_values + sum_of_too_small_positive_values
 		})
 		.max_by(|a, b| a.partial_cmp(b).unwrap())

--- a/crates/charts/lib.rs
+++ b/crates/charts/lib.rs
@@ -1,3 +1,6 @@
+#![warn(clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)]
+
 pub mod bar_chart;
 pub mod box_chart;
 pub mod chart;

--- a/crates/charts/tooltip.rs
+++ b/crates/charts/tooltip.rs
@@ -21,6 +21,7 @@ pub struct TooltipLabel {
 	pub text: String,
 }
 
+#[allow(clippy::too_many_lines)]
 pub fn draw_tooltip(options: DrawTooltipOptions) {
 	let DrawTooltipOptions {
 		center_horizontal,

--- a/crates/cli/serve.rs
+++ b/crates/cli/serve.rs
@@ -63,7 +63,7 @@ async fn predict(request: http::Request<hyper::Body>) -> http::Response<hyper::B
 		}
 	};
 	let outputs = PredictOutputs(modelfox_core::predict::predict(
-		&*context,
+		&context,
 		&inputs.inputs,
 		&inputs.options.unwrap_or_default(),
 	));

--- a/crates/cli/train.rs
+++ b/crates/cli/train.rs
@@ -239,7 +239,7 @@ fn progress_thread_handle_progress_event(
 		}
 		ProgressEvent::Load(progress_event) => match progress_event {
 			LoadProgressEvent::Train(progress_event) => match progress_event {
-				modelfox_table::LoadProgressEvent::InferStarted(progress_counter) => {
+				modelfox_table::ProgressEvent::InferStarted(progress_counter) => {
 					let progress_bar = ProgressBar::new(
 						"🤔",
 						"Inferring train table columns.".into(),
@@ -248,10 +248,10 @@ fn progress_thread_handle_progress_event(
 					);
 					start_progress_bar(terminal, state, progress_bar)?;
 				}
-				modelfox_table::LoadProgressEvent::InferDone => {
+				modelfox_table::ProgressEvent::InferDone => {
 					finish_progress_bar(terminal, state)?;
 				}
-				modelfox_table::LoadProgressEvent::LoadStarted(progress_counter) => {
+				modelfox_table::ProgressEvent::LoadStarted(progress_counter) => {
 					let progress_bar = ProgressBar::new(
 						"🚚",
 						"Loading train table.".into(),
@@ -260,12 +260,12 @@ fn progress_thread_handle_progress_event(
 					);
 					start_progress_bar(terminal, state, progress_bar)?;
 				}
-				modelfox_table::LoadProgressEvent::LoadDone => {
+				modelfox_table::ProgressEvent::LoadDone => {
 					finish_progress_bar(terminal, state)?;
 				}
 			},
 			LoadProgressEvent::Test(progress_event) => match progress_event {
-				modelfox_table::LoadProgressEvent::InferStarted(progress_counter) => {
+				modelfox_table::ProgressEvent::InferStarted(progress_counter) => {
 					let progress_bar = ProgressBar::new(
 						"🤔",
 						"Infer train table columns.".into(),
@@ -274,10 +274,10 @@ fn progress_thread_handle_progress_event(
 					);
 					start_progress_bar(terminal, state, progress_bar)?;
 				}
-				modelfox_table::LoadProgressEvent::InferDone => {
+				modelfox_table::ProgressEvent::InferDone => {
 					finish_progress_bar(terminal, state)?;
 				}
-				modelfox_table::LoadProgressEvent::LoadStarted(progress_counter) => {
+				modelfox_table::ProgressEvent::LoadStarted(progress_counter) => {
 					let progress_bar = ProgressBar::new(
 						"🚚",
 						"Loading test table.".into(),
@@ -286,7 +286,7 @@ fn progress_thread_handle_progress_event(
 					);
 					start_progress_bar(terminal, state, progress_bar)?;
 				}
-				modelfox_table::LoadProgressEvent::LoadDone => {
+				modelfox_table::ProgressEvent::LoadDone => {
 					finish_progress_bar(terminal, state)?;
 				}
 			},

--- a/crates/core/progress.rs
+++ b/crates/core/progress.rs
@@ -18,8 +18,8 @@ pub enum ProgressEvent {
 
 #[derive(Clone, Debug)]
 pub enum LoadProgressEvent {
-	Train(modelfox_table::LoadProgressEvent),
-	Test(modelfox_table::LoadProgressEvent),
+	Train(modelfox_table::ProgressEvent),
+	Test(modelfox_table::ProgressEvent),
 	Shuffle,
 	ShuffleDone,
 }

--- a/crates/dev/main.rs
+++ b/crates/dev/main.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::pedantic)]
+
 use clap::Parser;
 use std::path::PathBuf;
 

--- a/crates/finite/lib.rs
+++ b/crates/finite/lib.rs
@@ -11,6 +11,8 @@ assert!(Finite::new(n.get() / 0.0).is_err());
 ```
 */
 
+#![warn(clippy::pedantic)]
+
 use num::Float;
 use std::{
 	cmp::{Ord, Ordering},
@@ -38,6 +40,9 @@ impl<T> Finite<T>
 where
 	T: Float,
 {
+	/// # Errors
+	/// 
+	/// Returns an `Err` value is the passed value is not finite.
 	pub fn new(value: T) -> Result<Finite<T>, NotFiniteError> {
 		if value.is_finite() {
 			Ok(Finite(value))

--- a/crates/finite/lib.rs
+++ b/crates/finite/lib.rs
@@ -41,7 +41,7 @@ where
 	T: Float,
 {
 	/// # Errors
-	/// 
+	///
 	/// Returns an `Err` value is the passed value is not finite.
 	pub fn new(value: T) -> Result<Finite<T>, NotFiniteError> {
 		if value.is_finite() {

--- a/crates/id/lib.rs
+++ b/crates/id/lib.rs
@@ -1,11 +1,14 @@
 /*!
-ModelFox uses the `Id` type to uniquely identify models, users, and anything that needs a primary key. This type is almost identical to UUID v4, except there are no bits reserved to specify the version, and the string representation has no dashes.
+`ModelFox` uses the `Id` type to uniquely identify models, users, and anything that needs a primary key. This type is almost identical to UUID v4, except there are no bits reserved to specify the version, and the string representation has no dashes.
 */
+
+#![warn(clippy::pedantic)]
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Id(u128);
 
 impl Id {
+	#[must_use]
 	pub fn generate() -> Id {
 		Id(rand::random())
 	}

--- a/crates/kill_chip/lib.rs
+++ b/crates/kill_chip/lib.rs
@@ -1,13 +1,11 @@
+#![warn(clippy::pedantic)]
+
 use std::sync::atomic::{AtomicBool, Ordering};
 
 pub struct KillChip(AtomicBool);
 
 impl KillChip {
-	pub const fn new() -> Self {
-		KillChip(AtomicBool::new(false))
-	}
-
-	pub fn default() -> Self {
+	#[must_use] pub const fn new() -> Self {
 		KillChip(AtomicBool::new(false))
 	}
 
@@ -17,5 +15,11 @@ impl KillChip {
 
 	pub fn is_activated(&self) -> bool {
 		self.0.load(Ordering::SeqCst)
+	}
+}
+
+impl Default for KillChip {
+	fn default() -> Self {
+		KillChip(AtomicBool::new(false))
 	}
 }

--- a/crates/kill_chip/lib.rs
+++ b/crates/kill_chip/lib.rs
@@ -5,7 +5,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 pub struct KillChip(AtomicBool);
 
 impl KillChip {
-	#[must_use] pub const fn new() -> Self {
+	#[must_use]
+	pub const fn new() -> Self {
 		KillChip(AtomicBool::new(false))
 	}
 

--- a/crates/license/lib.rs
+++ b/crates/license/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::pedantic)]
+
 use anyhow::{anyhow, Result};
 use digest::Digest;
 use modelfox_id::Id;
@@ -9,6 +11,9 @@ use serde_json::json;
 
 pub const MODELFOX_LICENSE_PUBLIC_KEY: &str = include_str!("./license.public.rsa");
 
+/// # Errors
+/// 
+/// Return an error if the license data fails to serialize, or the data signing fails.
 pub fn generate(private_key: &str) -> Result<String> {
 	let private_key = RsaPrivateKey::from_pkcs1_pem(private_key)?;
 	let id = Id::generate();
@@ -28,6 +33,9 @@ pub fn generate(private_key: &str) -> Result<String> {
 	Ok(license)
 }
 
+/// # Errors
+/// 
+/// This function returns na error if the public key fails to parse and/or decode, or the data fails to varify against it.
 pub fn verify(license: &str, public_key: &str) -> Result<bool> {
 	let public_key = RsaPublicKey::from_pkcs1_pem(public_key)?;
 	let mut sections = license.split(|c| c == ':');

--- a/crates/license/lib.rs
+++ b/crates/license/lib.rs
@@ -12,7 +12,7 @@ use serde_json::json;
 pub const MODELFOX_LICENSE_PUBLIC_KEY: &str = include_str!("./license.public.rsa");
 
 /// # Errors
-/// 
+///
 /// Return an error if the license data fails to serialize, or the data signing fails.
 pub fn generate(private_key: &str) -> Result<String> {
 	let private_key = RsaPrivateKey::from_pkcs1_pem(private_key)?;
@@ -34,7 +34,7 @@ pub fn generate(private_key: &str) -> Result<String> {
 }
 
 /// # Errors
-/// 
+///
 /// This function returns na error if the public key fails to parse and/or decode, or the data fails to varify against it.
 pub fn verify(license: &str, public_key: &str) -> Result<bool> {
 	let public_key = RsaPublicKey::from_pkcs1_pem(public_key)?;

--- a/crates/progress_counter/lib.rs
+++ b/crates/progress_counter/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::pedantic)]
+
 use std::sync::{
 	atomic::{AtomicU64, Ordering},
 	Arc,
@@ -43,6 +45,7 @@ v.par_iter_mut().for_each(|v| {
 });
 ```
 */
+
 #[derive(Clone, Debug)]
 pub struct ProgressCounter {
 	current: Arc<AtomicU64>,
@@ -51,6 +54,7 @@ pub struct ProgressCounter {
 
 impl ProgressCounter {
 	/// Create a new `ProgressCounter` that will count from 0 up to the specified `total`.
+	#[must_use]
 	pub fn new(total: u64) -> ProgressCounter {
 		ProgressCounter {
 			current: Arc::new(AtomicU64::new(0)),
@@ -59,11 +63,13 @@ impl ProgressCounter {
 	}
 
 	/// Retrieve the total value this `ProgressCounter` counts up to.
+	#[must_use]
 	pub fn total(&self) -> u64 {
 		self.total
 	}
 
 	/// Retrieve the current progress value.
+	#[must_use]
 	pub fn get(&self) -> u64 {
 		self.current.load(Ordering::Relaxed)
 	}

--- a/crates/serve/lib.rs
+++ b/crates/serve/lib.rs
@@ -8,7 +8,7 @@ use modelfox_id::Id;
 use std::{cell::RefCell, convert::Infallible, panic::AssertUnwindSafe, sync::Arc};
 
 /// # Errors
-/// 
+///
 /// This function returns an error if `server.serve()` fails.
 pub async fn serve<C, H, F>(
 	addr: std::net::SocketAddr,

--- a/crates/serve/lib.rs
+++ b/crates/serve/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::pedantic)]
+
 use anyhow::Result;
 use backtrace::Backtrace;
 use futures::{future::FutureExt, Future};
@@ -5,6 +7,9 @@ use hyper::http;
 use modelfox_id::Id;
 use std::{cell::RefCell, convert::Infallible, panic::AssertUnwindSafe, sync::Arc};
 
+/// # Errors
+/// 
+/// This function returns an error if `server.serve()` fails.
 pub async fn serve<C, H, F>(
 	addr: std::net::SocketAddr,
 	context: Arc<C>,

--- a/crates/table/lib.rs
+++ b/crates/table/lib.rs
@@ -33,7 +33,7 @@ pub enum TableColumn {
 	Text(TextTableColumn),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnknownTableColumn {
 	name: Option<String>,
 	len: usize,
@@ -45,7 +45,7 @@ pub struct NumberTableColumn {
 	data: Vec<f32>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnumTableColumn {
 	name: Option<String>,
 	variants: Vec<String>,
@@ -53,7 +53,7 @@ pub struct EnumTableColumn {
 	variants_map: FnvHashMap<String, NonZeroUsize>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TextTableColumn {
 	name: Option<String>,
 	data: Vec<String>,
@@ -72,7 +72,7 @@ pub enum TableColumnView<'a> {
 	Text(TextTableColumnView<'a>),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnknownTableColumnView<'a> {
 	name: Option<&'a str>,
 	len: usize,
@@ -84,14 +84,14 @@ pub struct NumberTableColumnView<'a> {
 	data: &'a [f32],
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnumTableColumnView<'a> {
 	name: Option<&'a str>,
 	variants: &'a [String],
 	data: &'a [Option<NonZeroUsize>],
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TextTableColumnView<'a> {
 	name: Option<&'a str>,
 	data: &'a [String],
@@ -115,14 +115,14 @@ pub struct NumberTableColumnViewMut<'a> {
 	data: &'a mut [f32],
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct EnumTableColumnViewMut<'a> {
 	name: Option<&'a mut str>,
 	variants: &'a mut [String],
 	data: &'a mut [usize],
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct TextTableColumnViewMut<'a> {
 	name: Option<&'a mut str>,
 	data: &'a mut [String],

--- a/crates/table/lib.rs
+++ b/crates/table/lib.rs
@@ -2,7 +2,9 @@
 This crate implements two dimensional collections where each column can have a different data type, like a spreadsheet or database.
 */
 
-pub use self::load::{FromCsvOptions, LoadProgressEvent};
+#![warn(clippy::pedantic)]
+
+pub use self::load::{FromCsvOptions, ProgressEvent};
 use fnv::FnvHashMap;
 use modelfox_zip::zip;
 use ndarray::prelude::*;
@@ -153,6 +155,7 @@ pub enum TableValue<'a> {
 }
 
 impl Table {
+	#[must_use]
 	pub fn new(column_names: Vec<Option<String>>, column_types: Vec<TableColumnType>) -> Table {
 		let columns = zip!(column_names, column_types)
 			.map(|(column_name, column_type)| match column_type {
@@ -173,6 +176,7 @@ impl Table {
 		Table { columns }
 	}
 
+	#[must_use]
 	pub fn columns(&self) -> &Vec<TableColumn> {
 		&self.columns
 	}
@@ -187,19 +191,26 @@ impl Table {
 		}
 	}
 
+	#[must_use]
 	pub fn ncols(&self) -> usize {
 		self.columns.len()
 	}
 
+	#[must_use]
 	pub fn nrows(&self) -> usize {
-		self.columns.first().map(|column| column.len()).unwrap_or(0)
+		self.columns.first().map_or(0, TableColumn::len)
 	}
 
+	#[must_use]
 	pub fn view(&self) -> TableView {
-		let columns = self.columns.iter().map(|column| column.view()).collect();
+		let columns = self.columns.iter().map(TableColumn::view).collect();
 		TableView { columns }
 	}
 
+	/// # Panics
+	///
+	/// This function panics if unable to cast `NonZeroUsize` to `f32`.
+	#[must_use]
 	pub fn to_rows_f32(&self) -> Option<Array2<f32>> {
 		let mut features_train = Array::zeros((self.nrows(), self.ncols()));
 		for (mut ndarray_column, table_column) in
@@ -222,6 +233,7 @@ impl Table {
 		Some(features_train)
 	}
 
+	#[must_use]
 	pub fn to_rows(&self) -> Array2<TableValue> {
 		let mut rows = Array::from_elem((self.nrows(), self.ncols()), TableValue::Unknown);
 		for (mut ndarray_column, table_column) in
@@ -251,6 +263,7 @@ impl Table {
 }
 
 impl TableColumn {
+	#[must_use]
 	pub fn len(&self) -> usize {
 		match self {
 			TableColumn::Unknown(s) => s.len(),
@@ -260,6 +273,7 @@ impl TableColumn {
 		}
 	}
 
+	#[must_use]
 	pub fn is_empty(&self) -> bool {
 		match self {
 			TableColumn::Unknown(s) => s.len == 0,
@@ -269,6 +283,7 @@ impl TableColumn {
 		}
 	}
 
+	#[must_use]
 	pub fn name(&self) -> Option<&str> {
 		match self {
 			TableColumn::Unknown(s) => s.name.as_deref(),
@@ -281,13 +296,13 @@ impl TableColumn {
 	pub fn drop_row(&mut self, idx: usize) {
 		match self {
 			TableColumn::Enum(etc) => {
-				let _ = etc.data_mut().remove(idx);
+				let _data = etc.data_mut().remove(idx);
 			}
 			TableColumn::Number(ntc) => {
-				let _ = ntc.data_mut().remove(idx);
+				let _data = ntc.data_mut().remove(idx);
 			}
 			TableColumn::Text(ttc) => {
-				let _ = ttc.data_mut().remove(idx);
+				let _data = ttc.data_mut().remove(idx);
 			}
 			TableColumn::Unknown(utc) => {
 				let len = utc.len_mut();
@@ -296,6 +311,7 @@ impl TableColumn {
 		}
 	}
 
+	#[must_use]
 	pub fn as_number(&self) -> Option<&NumberTableColumn> {
 		match self {
 			TableColumn::Number(s) => Some(s),
@@ -303,6 +319,7 @@ impl TableColumn {
 		}
 	}
 
+	#[must_use]
 	pub fn as_enum(&self) -> Option<&EnumTableColumn> {
 		match self {
 			TableColumn::Enum(s) => Some(s),
@@ -310,6 +327,7 @@ impl TableColumn {
 		}
 	}
 
+	#[must_use]
 	pub fn as_text(&self) -> Option<&TextTableColumn> {
 		match self {
 			TableColumn::Text(s) => Some(s),
@@ -338,6 +356,7 @@ impl TableColumn {
 		}
 	}
 
+	#[must_use]
 	pub fn view(&self) -> TableColumnView {
 		match self {
 			TableColumn::Unknown(column) => TableColumnView::Unknown(column.view()),
@@ -349,18 +368,22 @@ impl TableColumn {
 }
 
 impl UnknownTableColumn {
+	#[must_use]
 	pub fn new(name: Option<String>) -> UnknownTableColumn {
 		UnknownTableColumn { name, len: 0 }
 	}
 
+	#[must_use]
 	pub fn name(&self) -> &Option<String> {
 		&self.name
 	}
 
+	#[must_use]
 	pub fn is_empty(&self) -> bool {
 		self.len == 0
 	}
 
+	#[must_use]
 	pub fn len(&self) -> usize {
 		self.len
 	}
@@ -369,6 +392,7 @@ impl UnknownTableColumn {
 		&mut self.len
 	}
 
+	#[must_use]
 	pub fn view(&self) -> UnknownTableColumnView {
 		UnknownTableColumnView {
 			name: self.name.as_deref(),
@@ -378,18 +402,22 @@ impl UnknownTableColumn {
 }
 
 impl NumberTableColumn {
+	#[must_use]
 	pub fn new(name: Option<String>, data: Vec<f32>) -> NumberTableColumn {
 		NumberTableColumn { name, data }
 	}
 
+	#[must_use]
 	pub fn name(&self) -> &Option<String> {
 		&self.name
 	}
 
+	#[must_use]
 	pub fn is_empty(&self) -> bool {
 		self.data.len() == 0
 	}
 
+	#[must_use]
 	pub fn len(&self) -> usize {
 		self.data.len()
 	}
@@ -406,6 +434,7 @@ impl NumberTableColumn {
 		&mut self.data
 	}
 
+	#[must_use]
 	pub fn view(&self) -> NumberTableColumnView {
 		NumberTableColumnView {
 			name: self.name.as_deref(),
@@ -415,6 +444,10 @@ impl NumberTableColumn {
 }
 
 impl EnumTableColumn {
+	/// # Panics
+	///
+	/// This function panics if the number of variants overflows a `NonZeroUsize`.
+	#[must_use]
 	pub fn new(
 		name: Option<String>,
 		variants: Vec<String>,
@@ -434,18 +467,22 @@ impl EnumTableColumn {
 		}
 	}
 
+	#[must_use]
 	pub fn name(&self) -> &Option<String> {
 		&self.name
 	}
 
+	#[must_use]
 	pub fn variants(&self) -> &[String] {
 		&self.variants
 	}
 
+	#[must_use]
 	pub fn is_empty(&self) -> bool {
 		self.data.len() == 0
 	}
 
+	#[must_use]
 	pub fn len(&self) -> usize {
 		self.data.len()
 	}
@@ -458,6 +495,7 @@ impl EnumTableColumn {
 		&mut self.data
 	}
 
+	#[must_use]
 	pub fn view(&self) -> EnumTableColumnView {
 		EnumTableColumnView {
 			name: self.name.as_deref(),
@@ -466,24 +504,29 @@ impl EnumTableColumn {
 		}
 	}
 
+	#[must_use]
 	pub fn value_for_variant(&self, variant: &str) -> Option<NonZeroUsize> {
-		self.variants_map.get(variant).cloned()
+		self.variants_map.get(variant).copied()
 	}
 }
 
 impl TextTableColumn {
+	#[must_use]
 	pub fn new(name: Option<String>, data: Vec<String>) -> TextTableColumn {
 		TextTableColumn { name, data }
 	}
 
+	#[must_use]
 	pub fn name(&self) -> &Option<String> {
 		&self.name
 	}
 
+	#[must_use]
 	pub fn is_empty(&self) -> bool {
 		self.data.len() == 0
 	}
 
+	#[must_use]
 	pub fn len(&self) -> usize {
 		self.data.len()
 	}
@@ -496,6 +539,7 @@ impl TextTableColumn {
 		&mut self.data
 	}
 
+	#[must_use]
 	pub fn view(&self) -> TextTableColumnView {
 		TextTableColumnView {
 			name: self.name.as_deref(),
@@ -505,26 +549,31 @@ impl TextTableColumn {
 }
 
 impl<'a> TableView<'a> {
+	#[must_use]
 	pub fn columns(&self) -> &Vec<TableColumnView<'a>> {
 		&self.columns
 	}
 
+	#[must_use]
 	pub fn view_columns(&self, column_indexes: &[usize]) -> TableView {
 		let mut columns = Vec::with_capacity(column_indexes.len());
 		for column_index in column_indexes {
-			columns.push(self.columns[*column_index].clone())
+			columns.push(self.columns[*column_index].clone());
 		}
 		Self { columns }
 	}
 
+	#[must_use]
 	pub fn ncols(&self) -> usize {
 		self.columns.len()
 	}
 
+	#[must_use]
 	pub fn nrows(&self) -> usize {
-		self.columns.first().map(|column| column.len()).unwrap_or(0)
+		self.columns.first().map_or(0, TableColumnView::len)
 	}
 
+	#[must_use]
 	pub fn view(&self) -> TableView {
 		self.clone()
 	}
@@ -540,6 +589,7 @@ impl<'a> TableView<'a> {
 		}
 	}
 
+	#[must_use]
 	pub fn split_at_row(&self, index: usize) -> (TableView<'a>, TableView<'a>) {
 		let iter = self.columns.iter().map(|column| column.split_at_row(index));
 		let mut columns_a = Vec::with_capacity(self.columns.len());
@@ -554,6 +604,10 @@ impl<'a> TableView<'a> {
 		)
 	}
 
+	/// # Panics
+	///
+	/// This function panics if unable to cast `NonZeroUsize` to `f32.`
+	#[must_use]
 	pub fn to_rows_f32(&self) -> Option<Array2<f32>> {
 		let mut features_train = Array::zeros((self.nrows(), self.ncols()));
 		for (mut ndarray_column, table_column) in
@@ -576,6 +630,7 @@ impl<'a> TableView<'a> {
 		Some(features_train)
 	}
 
+	#[must_use]
 	pub fn to_rows(&self) -> Array2<TableValue<'a>> {
 		let mut rows = Array::from_elem((self.nrows(), self.ncols()), TableValue::Unknown);
 		for (mut ndarray_column, table_column) in
@@ -605,6 +660,7 @@ impl<'a> TableView<'a> {
 }
 
 impl<'a> TableColumnView<'a> {
+	#[must_use]
 	pub fn len(&self) -> usize {
 		match self {
 			TableColumnView::Unknown(s) => s.len,
@@ -614,6 +670,7 @@ impl<'a> TableColumnView<'a> {
 		}
 	}
 
+	#[must_use]
 	pub fn is_empty(&self) -> bool {
 		match self {
 			TableColumnView::Unknown(s) => s.len == 0,
@@ -623,6 +680,7 @@ impl<'a> TableColumnView<'a> {
 		}
 	}
 
+	#[must_use]
 	pub fn name(&self) -> Option<&str> {
 		match self {
 			TableColumnView::Unknown(s) => s.name,
@@ -632,6 +690,7 @@ impl<'a> TableColumnView<'a> {
 		}
 	}
 
+	#[must_use]
 	pub fn column_type(&self) -> TableColumnTypeView {
 		match self {
 			TableColumnView::Unknown(_) => TableColumnTypeView::Unknown,
@@ -643,6 +702,7 @@ impl<'a> TableColumnView<'a> {
 		}
 	}
 
+	#[must_use]
 	pub fn as_number(&self) -> Option<NumberTableColumnView> {
 		match self {
 			TableColumnView::Number(s) => Some(s.clone()),
@@ -650,6 +710,7 @@ impl<'a> TableColumnView<'a> {
 		}
 	}
 
+	#[must_use]
 	pub fn as_enum(&self) -> Option<EnumTableColumnView> {
 		match self {
 			TableColumnView::Enum(s) => Some(s.clone()),
@@ -657,6 +718,7 @@ impl<'a> TableColumnView<'a> {
 		}
 	}
 
+	#[must_use]
 	pub fn as_text(&self) -> Option<TextTableColumnView> {
 		match self {
 			TableColumnView::Text(s) => Some(s.clone()),
@@ -664,6 +726,7 @@ impl<'a> TableColumnView<'a> {
 		}
 	}
 
+	#[must_use]
 	pub fn split_at_row(&self, index: usize) -> (TableColumnView<'a>, TableColumnView<'a>) {
 		match self {
 			TableColumnView::Unknown(column) => (
@@ -720,6 +783,7 @@ impl<'a> TableColumnView<'a> {
 		}
 	}
 
+	#[must_use]
 	pub fn view(&self) -> TableColumnView {
 		match self {
 			TableColumnView::Unknown(s) => TableColumnView::Unknown(s.view()),
@@ -731,36 +795,44 @@ impl<'a> TableColumnView<'a> {
 }
 
 impl<'a> UnknownTableColumnView<'a> {
+	#[must_use]
 	pub fn name(&self) -> Option<&str> {
 		self.name
 	}
 
+	#[must_use]
 	pub fn is_empty(&self) -> bool {
 		self.len == 0
 	}
 
+	#[must_use]
 	pub fn len(&self) -> usize {
 		self.len
 	}
 
+	#[must_use]
 	pub fn view(&self) -> UnknownTableColumnView {
 		self.clone()
 	}
 }
 
 impl<'a> NumberTableColumnView<'a> {
+	#[must_use]
 	pub fn name(&self) -> Option<&str> {
 		self.name
 	}
 
+	#[must_use]
 	pub fn data(&self) -> &[f32] {
 		self.data
 	}
 
+	#[must_use]
 	pub fn is_empty(&self) -> bool {
 		self.data.len() == 0
 	}
 
+	#[must_use]
 	pub fn len(&self) -> usize {
 		self.data.len()
 	}
@@ -769,32 +841,39 @@ impl<'a> NumberTableColumnView<'a> {
 		self.data.iter()
 	}
 
+	#[must_use]
 	pub fn as_slice(&self) -> &[f32] {
 		self.data
 	}
 
+	#[must_use]
 	pub fn view(&self) -> NumberTableColumnView {
 		self.clone()
 	}
 }
 
 impl<'a> EnumTableColumnView<'a> {
+	#[must_use]
 	pub fn name(&self) -> Option<&str> {
 		self.name
 	}
 
+	#[must_use]
 	pub fn data(&self) -> &[Option<NonZeroUsize>] {
 		self.data
 	}
 
+	#[must_use]
 	pub fn variants(&self) -> &[String] {
 		self.variants
 	}
 
+	#[must_use]
 	pub fn is_empty(&self) -> bool {
 		self.data.len() == 0
 	}
 
+	#[must_use]
 	pub fn len(&self) -> usize {
 		self.data.len()
 	}
@@ -803,28 +882,34 @@ impl<'a> EnumTableColumnView<'a> {
 		self.data.iter()
 	}
 
+	#[must_use]
 	pub fn as_slice(&self) -> &[Option<NonZeroUsize>] {
 		self.data
 	}
 
+	#[must_use]
 	pub fn view(&self) -> EnumTableColumnView {
 		self.clone()
 	}
 }
 
 impl<'a> TextTableColumnView<'a> {
+	#[must_use]
 	pub fn name(&self) -> Option<&str> {
 		self.name
 	}
 
+	#[must_use]
 	pub fn data(&self) -> &'a [String] {
 		self.data
 	}
 
+	#[must_use]
 	pub fn is_empty(&self) -> bool {
 		self.data.len() == 0
 	}
 
+	#[must_use]
 	pub fn len(&self) -> usize {
 		self.data.len()
 	}
@@ -833,16 +918,19 @@ impl<'a> TextTableColumnView<'a> {
 		self.data.iter()
 	}
 
+	#[must_use]
 	pub fn as_slice(&self) -> &[String] {
 		self.data
 	}
 
+	#[must_use]
 	pub fn view(&self) -> TextTableColumnView {
 		self.clone()
 	}
 }
 
 impl<'a> TableValue<'a> {
+	#[must_use]
 	pub fn as_number(&self) -> Option<&f32> {
 		match self {
 			TableValue::Number(s) => Some(s),
@@ -857,6 +945,7 @@ impl<'a> TableValue<'a> {
 		}
 	}
 
+	#[must_use]
 	pub fn as_enum(&self) -> Option<&Option<NonZeroUsize>> {
 		match self {
 			TableValue::Enum(s) => Some(s),
@@ -871,6 +960,7 @@ impl<'a> TableValue<'a> {
 		}
 	}
 
+	#[must_use]
 	pub fn as_text(&self) -> Option<&str> {
 		match self {
 			TableValue::Text(s) => Some(s),

--- a/crates/tree/lib.rs
+++ b/crates/tree/lib.rs
@@ -251,7 +251,7 @@ pub struct BranchSplitContinuous {
 	pub invalid_values_direction: SplitDirection,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SplitDirection {
 	Left,
 	Right,

--- a/crates/ui/code.rs
+++ b/crates/ui/code.rs
@@ -15,7 +15,7 @@ pub struct Code {
 	pub line_numbers: Option<bool>,
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Language {
 	Elixir,
 	Go,

--- a/crates/www/layouts/docs_layout.rs
+++ b/crates/www/layouts/docs_layout.rs
@@ -18,7 +18,7 @@ pub struct Heading {
 	title: String,
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum DocsPage {
 	Overview,
 	Install,
@@ -27,7 +27,7 @@ pub enum DocsPage {
 	Internals(String),
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum GettingStartedPage {
 	Index,
 	Train,
@@ -36,7 +36,7 @@ pub enum GettingStartedPage {
 	Monitor,
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum PredictPage {
 	Index,
 	CLI,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-05-13"
+channel = "nightly-2022-07-03"
 components = [ "clippy", "rustfmt" ]
 targets = [ 
 	"aarch64-unknown-linux-gnu",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-07-03"
+channel = "nightly-2022-05-13"
 components = [ "clippy", "rustfmt" ]
 targets = [ 
 	"aarch64-unknown-linux-gnu",


### PR DESCRIPTION
This PR bumps the toolchain to a current nightly with version `1.64.0`, updates the Cargo dependencies, and applies the `clippy::pedantic` lint level to the following crates:

- `modelfox_build`
- `modelfox_charts`
- `modelfox_dev`
- `modelfox_finite`
- `modelfox_id`
- `modelfox_kill_chip`
- `modelfox_license`
- `modelfox_number_formatter`
- `modelfox_serve`
- `modelfox_table`